### PR TITLE
PSPDOC-1777

### DIFF
--- a/content/index/integration-options/09-shop-systems.adoc
+++ b/content/index/integration-options/09-shop-systems.adoc
@@ -301,12 +301,15 @@ a| WooCommerce
 
       - Chinese, simplified
       - Chinese, traditional
+      - Czech
+      - Dutch
       - English
       - French
       - German
       - Indonesian
       - Japanese
-      - Korean   |
+      - Korean   
+      - Slovak   |
 
       - https://github.com/wirecard/woocommerce-ee/wiki[English]
       - https://github.com/wirecard/woocommerce-ee/wiki/Accueil[French]


### PR DESCRIPTION
Add Czech, Dutch, Slovak for WooCommerce as supported languages.